### PR TITLE
Update to use query token auth.

### DIFF
--- a/lib/updateLastSessionDate.js
+++ b/lib/updateLastSessionDate.js
@@ -5,13 +5,12 @@ module.exports = async function(userToken, userAgent) {
   const token = typeof userToken === 'object' ? userToken.userToken : userToken;
   const params = {
     payload: {
-      token,
       userAgent,
       incSessions: 1,
       lastSessionDate: new Date()
     },
     json: true
   };
-  const response = await wreck.put(`${config.host}/api/users`, params);
+  const response = await wreck.put(`${config.host}/api/users?token=${token}`, params);
   return response.payload;
 };

--- a/test/server.test.js
+++ b/test/server.test.js
@@ -31,7 +31,7 @@ lab.experiment('server actions', () => {
       path: '/api/users',
       method: 'put',
       handler(r, h) {
-        code.expect(r.payload.token).to.equal('aToken');
+        code.expect(r.query.token).to.equal('aToken');
         const result = Object.assign({}, r.payload);
         result._id = '5678';
         return result;


### PR DESCRIPTION
Since auth scheme's can't read payload information.